### PR TITLE
lavender: overlay:  Ignore RSSNR Signal Level

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -348,4 +348,7 @@
 
     <!-- Whether or not swipe up gesture's opt-in setting is available on this device -->
     <bool name="config_swipe_up_gesture_setting_available">true</bool>
+
+    <!-- Whether device ignores the RSSNR signal implementation -->
+    <bool name="config_ignoreRssnrSignalLevel">true</bool>
 </resources>


### PR DESCRIPTION
Signed-off-by: AmulyaX <amulya.b520@gmail.com>

*When rssnr signal levels are showing it shows null signal bars in status bar even getting 90 to 95dbm
*It maybe not following dbm to measure signals on status bar